### PR TITLE
Add SSH remote monitoring support

### DIFF
--- a/src/control_center_manager.py
+++ b/src/control_center_manager.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from ipc_tcp_client import connect_to_agent, TlsNegotiationError
 from ipc_tcp_auth import AuthError
 from zfs_manager import ZfsManagerClient
+from ssh_zfs_client import SshZfsManagerClient
 
 # TLS certificate trust management
 from tls_manager import remove_trusted_certificate
@@ -29,9 +30,20 @@ from debug_logging import log_debug, log_info, log_error, log_warning, log_criti
 
 
 class AgentConnection:
-    """Represents a remote ZFS agent connection."""
+    """Represents a remote ZFS connection."""
     
-    def __init__(self, alias: str, host: str, port: int, use_tls: bool = True):
+    def __init__(
+        self,
+        alias: str,
+        host: str,
+        port: int,
+        use_tls: bool = True,
+        connection_type: str = "agent",
+        ssh_user: str = "root",
+        auth_method: str = "password",
+        ssh_key_path: str = "",
+        allow_ssh_actions: bool = False,
+    ):
         """
         Initialize an agent connection.
         
@@ -45,7 +57,12 @@ class AgentConnection:
         self.host = host
         self.port = port
         self.use_tls = use_tls  # User preference for TLS
-        self.client: Optional[ZfsManagerClient] = None
+        self.connection_type = connection_type if connection_type in ("agent", "ssh") else "agent"
+        self.ssh_user = ssh_user or "root"
+        self.auth_method = auth_method if auth_method in ("password", "key") else "password"
+        self.ssh_key_path = ssh_key_path or ""
+        self.allow_ssh_actions = bool(allow_ssh_actions)
+        self.client: Optional[Any] = None
         self.connected = False
         self.tls_active = False  # True only if TLS handshake succeeded
         self.last_error: Optional[str] = None
@@ -58,17 +75,36 @@ class AgentConnection:
             'host': self.host,
             'port': self.port,
             'use_tls': self.use_tls,
+            'type': self.connection_type,
+            'ssh_user': self.ssh_user,
+            'ssh_port': self.port if self.connection_type == "ssh" else 22,
+            'auth_method': self.auth_method,
+            'ssh_key_path': self.ssh_key_path,
+            'allow_ssh_actions': self.allow_ssh_actions,
             'last_connected': self.last_connected
         }
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'AgentConnection':
         """Create connection from stored dictionary."""
+        connection_type = data.get('type', data.get('connection_type', 'agent'))
+        port = data.get('port')
+        if connection_type == "ssh":
+            port = data.get('ssh_port', port if port else 22)
+            # Legacy UI could save SSH hosts with the Agent default port.
+            if int(port) == 5555:
+                port = 22
+
         conn = cls(
             alias=data['alias'],
             host=data['host'],
-            port=data['port'],
-            use_tls=data.get('use_tls', True)  # Default True for backward compatibility
+            port=int(port),
+            use_tls=data.get('use_tls', True),  # Default True for backward compatibility
+            connection_type=connection_type,
+            ssh_user=data.get('ssh_user', 'root'),
+            auth_method=data.get('auth_method', 'password'),
+            ssh_key_path=data.get('ssh_key_path', ''),
+            allow_ssh_actions=data.get('allow_ssh_actions', False),
         )
         conn.last_connected = data.get('last_connected')
         return conn
@@ -88,7 +124,18 @@ class ControlCenterManager:
         self.storage_path = storage_path
         self.active_alias: Optional[str] = None  # Currently active remote alias
         
-    def add_connection(self, alias: str, host: str, port: int, use_tls: bool = True) -> Tuple[bool, str]:
+    def add_connection(
+        self,
+        alias: str,
+        host: str,
+        port: int,
+        use_tls: bool = True,
+        connection_type: str = "agent",
+        ssh_user: str = "root",
+        auth_method: str = "password",
+        ssh_key_path: str = "",
+        allow_ssh_actions: bool = False,
+    ) -> Tuple[bool, str]:
         """
         Add a new agent connection.
         
@@ -110,13 +157,30 @@ class ControlCenterManager:
         if not host or not host.strip():
             return False, "Host cannot be empty"
         
+        if connection_type not in ("agent", "ssh"):
+            return False, f"Invalid connection type: {connection_type}"
+
         if not isinstance(port, int) or port < 1 or port > 65535:
             return False, f"Invalid port number: {port}"
+
+        if connection_type == "ssh" and auth_method not in ("password", "key"):
+            return False, f"Invalid SSH auth method: {auth_method}"
         
         try:
-            self.connections[alias] = AgentConnection(alias, host, port, use_tls)
+            self.connections[alias] = AgentConnection(
+                alias,
+                host,
+                port,
+                use_tls,
+                connection_type=connection_type,
+                ssh_user=ssh_user,
+                auth_method=auth_method,
+                ssh_key_path=ssh_key_path,
+                allow_ssh_actions=allow_ssh_actions,
+            )
             self.save_connections()
-            return True, f"Agent '{alias}' added successfully"
+            label = "SSH host" if connection_type == "ssh" else "Agent"
+            return True, f"{label} '{alias}' added successfully"
         except Exception as e:
             return False, f"Failed to add connection: {e}"
     
@@ -184,21 +248,32 @@ class ControlCenterManager:
             conn.client = None
             conn.connected = False
         
-        # Use saved TLS preference
-        use_tls = conn.use_tls
-        
         try:
-            # Connect using TCP client transport
-            log_debug("CC_MANAGER", f"Connecting to {conn.host}:{conn.port} (TLS: {use_tls})...")
-            transport, tls_active = connect_to_agent(conn.host, conn.port, password, timeout=30.0, use_tls=use_tls)
-            
-            # Create ZfsManagerClient with the transport
-            # owns_daemon=False because this is an external agent
-            conn.client = ZfsManagerClient(
-                daemon_process=None,
-                transport=transport,
-                owns_daemon=False
-            )
+            if conn.connection_type == "ssh":
+                log_debug("CC_MANAGER", f"Connecting to SSH {conn.ssh_user}@{conn.host}:{conn.port}...")
+                conn.client = SshZfsManagerClient(
+                    conn.host,
+                    port=conn.port,
+                    username=conn.ssh_user,
+                    password=password or None,
+                    auth_method=conn.auth_method,
+                    key_path=conn.ssh_key_path or None,
+                    allow_actions=conn.allow_ssh_actions,
+                )
+                tls_active = False
+            else:
+                # Use saved TLS preference
+                use_tls = conn.use_tls
+                log_debug("CC_MANAGER", f"Connecting to {conn.host}:{conn.port} (TLS: {use_tls})...")
+                transport, tls_active = connect_to_agent(conn.host, conn.port, password, timeout=30.0, use_tls=use_tls)
+
+                # Create ZfsManagerClient with the transport
+                # owns_daemon=False because this is an external agent
+                conn.client = ZfsManagerClient(
+                    daemon_process=None,
+                    transport=transport,
+                    owns_daemon=False
+                )
             
             conn.connected = True
             conn.tls_active = tls_active
@@ -211,7 +286,10 @@ class ControlCenterManager:
             self.save_connections()
             
             # Return success with appropriate message
-            if tls_active:
+            if conn.connection_type == "ssh":
+                mode = "read/write actions enabled" if conn.allow_ssh_actions else "read-only"
+                return True, f"Connected to SSH host '{alias}' ({mode})", None
+            elif tls_active:
                 return True, f"Connected to '{alias}' (TLS encrypted)", None
             else:
                 return True, f"⚠️ Connected to '{alias}' WITHOUT encryption", None
@@ -300,6 +378,31 @@ class ControlCenterManager:
         session['cc_active_alias'] = alias
         
         return True, f"Switched to remote agent '{alias}'"
+
+    def restore_active_from_session(self, session: Dict) -> Optional[str]:
+        """
+        Restore active connection state from Flask session when the request
+        context still knows the selected remote but this manager instance does not.
+
+        This can happen after route reloads or other in-process state resets while
+        the SSH/agent client object is still alive in the connection record.
+        """
+        if self.active_alias:
+            return self.active_alias
+
+        if session.get('cc_mode') != 'remote':
+            return None
+
+        alias = session.get('cc_active_alias')
+        if not alias or alias not in self.connections:
+            return None
+
+        conn = self.connections[alias]
+        if not conn.connected or not conn.client:
+            return None
+
+        self.active_alias = alias
+        return alias
     
     def is_healthy_or_clear(self) -> Tuple[bool, Optional[str]]:
         """
@@ -389,6 +492,11 @@ class ControlCenterManager:
                 'host': conn.host,
                 'port': conn.port,
                 'use_tls': conn.use_tls,
+                'type': conn.connection_type,
+                'ssh_user': conn.ssh_user,
+                'auth_method': conn.auth_method,
+                'ssh_key_path': conn.ssh_key_path,
+                'allow_ssh_actions': conn.allow_ssh_actions,
                 'connected': conn.connected and is_healthy,  # Use live health check
                 'tls_active': conn.tls_active,
                 'active': alias == self.active_alias,
@@ -397,7 +505,19 @@ class ControlCenterManager:
             })
         return result
     
-    def update_connection(self, old_alias: str, new_alias: str, host: str, port: int, use_tls: bool) -> Tuple[bool, str]:
+    def update_connection(
+        self,
+        old_alias: str,
+        new_alias: str,
+        host: str,
+        port: int,
+        use_tls: bool,
+        connection_type: str = "agent",
+        ssh_user: str = "root",
+        auth_method: str = "password",
+        ssh_key_path: str = "",
+        allow_ssh_actions: bool = False,
+    ) -> Tuple[bool, str]:
         """
         Update an existing agent connection.
         
@@ -423,6 +543,12 @@ class ControlCenterManager:
         
         if not isinstance(port, int) or port < 1 or port > 65535:
             return False, f"Invalid port number: {port}"
+
+        if connection_type not in ("agent", "ssh"):
+            return False, f"Invalid connection type: {connection_type}"
+
+        if connection_type == "ssh" and auth_method not in ("password", "key"):
+            return False, f"Invalid SSH auth method: {auth_method}"
         
         # Check if new alias conflicts with existing (different) connection
         if new_alias != old_alias and new_alias in self.connections:
@@ -449,6 +575,11 @@ class ControlCenterManager:
         conn.host = host.strip()
         conn.port = port
         conn.use_tls = use_tls
+        conn.connection_type = connection_type
+        conn.ssh_user = ssh_user or "root"
+        conn.auth_method = auth_method if auth_method in ("password", "key") else "password"
+        conn.ssh_key_path = ssh_key_path or ""
+        conn.allow_ssh_actions = bool(allow_ssh_actions)
         conn.last_error = None
         
         # If alias changed, update the dict key

--- a/src/control_center_routes.py
+++ b/src/control_center_routes.py
@@ -9,6 +9,7 @@ This module provides REST API endpoints for managing remote ZFS agent connection
 """
 
 from flask import Blueprint, request, jsonify, session
+from flask_login import login_required
 from typing import Tuple
 
 # Create Blueprint
@@ -30,6 +31,7 @@ def init_control_center_routes(cc_manager):
 
 
 @control_center_bp.route('/add', methods=['POST'])
+@login_required
 def add_agent():
     """Add a new remote agent connection."""
     if not _cc_manager:
@@ -42,7 +44,12 @@ def add_agent():
     alias = data.get('alias', '').strip()
     host = data.get('host', '').strip()
     port = data.get('port')
+    connection_type = data.get('type', 'agent')
     use_tls = data.get('use_tls', True)  # Default to True if not specified
+    ssh_user = (data.get('ssh_user') or 'root').strip()
+    auth_method = data.get('auth_method', 'password')
+    ssh_key_path = (data.get('ssh_key_path') or '').strip()
+    allow_ssh_actions = data.get('allow_ssh_actions', False)
     
     if not alias:
         return jsonify({'success': False, 'error': 'Alias is required'}), 400
@@ -57,8 +64,20 @@ def add_agent():
     # Convert use_tls to bool if it's a string
     if isinstance(use_tls, str):
         use_tls = use_tls.lower() in ('true', '1', 'yes')
+    if isinstance(allow_ssh_actions, str):
+        allow_ssh_actions = allow_ssh_actions.lower() in ('true', '1', 'yes')
     
-    success, message = _cc_manager.add_connection(alias, host, port, use_tls)
+    success, message = _cc_manager.add_connection(
+        alias,
+        host,
+        port,
+        use_tls,
+        connection_type=connection_type,
+        ssh_user=ssh_user,
+        auth_method=auth_method,
+        ssh_key_path=ssh_key_path,
+        allow_ssh_actions=allow_ssh_actions,
+    )
     
     if success:
         return jsonify({'success': True, 'message': message})
@@ -67,6 +86,7 @@ def add_agent():
 
 
 @control_center_bp.route('/remove', methods=['POST'])
+@login_required
 def remove_agent():
     """Remove a remote agent connection."""
     if not _cc_manager:
@@ -91,6 +111,7 @@ def remove_agent():
 
 
 @control_center_bp.route('/connect', methods=['POST'])
+@login_required
 def connect_agent():
     """Connect to a remote agent (requires password)."""
     if not _cc_manager:
@@ -105,7 +126,8 @@ def connect_agent():
     
     if not alias:
         return jsonify({'success': False, 'error': 'Alias is required'}), 400
-    if not password:
+    conn = _cc_manager.connections.get(alias) if _cc_manager else None
+    if (not conn or conn.connection_type != 'ssh' or conn.auth_method == 'password') and not password:
         return jsonify({'success': False, 'error': 'Password is required'}), 400
     
     # Get agent's configured TLS setting for error response
@@ -130,6 +152,7 @@ def connect_agent():
 
 
 @control_center_bp.route('/disconnect', methods=['POST'])
+@login_required
 def disconnect_agent():
     """Disconnect from a remote agent."""
     if not _cc_manager:
@@ -154,6 +177,7 @@ def disconnect_agent():
 
 
 @control_center_bp.route('/switch/<alias>', methods=['POST'])
+@login_required
 def switch_agent(alias):
     """Switch to a different active agent (or 'local' for local daemon)."""
     if not _cc_manager:
@@ -172,12 +196,15 @@ def switch_agent(alias):
 
 
 @control_center_bp.route('/list', methods=['GET'])
+@login_required
 def list_agents():
     """List all configured remote agents with their status."""
     if not _cc_manager:
         return jsonify({'success': False, 'error': 'Control center not initialized'}), 500
     
     try:
+        _cc_manager.restore_active_from_session(session)
+
         # Validate active connection (single source of truth - auto-clears dead connections)
         is_healthy, active_alias = _cc_manager.is_healthy_or_clear()
         
@@ -200,6 +227,7 @@ def list_agents():
 
 
 @control_center_bp.route('/health/<alias>', methods=['GET'])
+@login_required
 def check_agent_health(alias):
     """Check if a specific agent connection is healthy."""
     if not _cc_manager:
@@ -219,6 +247,7 @@ def check_agent_health(alias):
 
 
 @control_center_bp.route('/update_tls', methods=['POST'])
+@login_required
 def update_tls():
     """Update TLS preference for an agent."""
     if not _cc_manager:
@@ -249,6 +278,7 @@ def update_tls():
 
 
 @control_center_bp.route('/update', methods=['POST'])
+@login_required
 def update_agent():
     """Update an existing agent connection."""
     if not _cc_manager:
@@ -262,7 +292,12 @@ def update_agent():
     new_alias = data.get('alias', '').strip()
     host = data.get('host', '').strip()
     port = data.get('port')
+    connection_type = data.get('type', 'agent')
     use_tls = data.get('use_tls', True)
+    ssh_user = (data.get('ssh_user') or 'root').strip()
+    auth_method = data.get('auth_method', 'password')
+    ssh_key_path = (data.get('ssh_key_path') or '').strip()
+    allow_ssh_actions = data.get('allow_ssh_actions', False)
     
     if not old_alias:
         return jsonify({'success': False, 'error': 'Original alias is required'}), 400
@@ -279,8 +314,21 @@ def update_agent():
     # Convert use_tls to bool if string
     if isinstance(use_tls, str):
         use_tls = use_tls.lower() in ('true', '1', 'yes')
+    if isinstance(allow_ssh_actions, str):
+        allow_ssh_actions = allow_ssh_actions.lower() in ('true', '1', 'yes')
     
-    success, message = _cc_manager.update_connection(old_alias, new_alias, host, port, use_tls)
+    success, message = _cc_manager.update_connection(
+        old_alias,
+        new_alias,
+        host,
+        port,
+        use_tls,
+        connection_type=connection_type,
+        ssh_user=ssh_user,
+        auth_method=auth_method,
+        ssh_key_path=ssh_key_path,
+        allow_ssh_actions=allow_ssh_actions,
+    )
     
     if success:
         # Clear session data for old alias if it changed
@@ -292,6 +340,7 @@ def update_agent():
 
 
 @control_center_bp.route('/discover', methods=['POST'])
+@login_required
 def discover_agents():
     """
     Scan network for available ZFS agents.

--- a/src/ssh_zfs_client.py
+++ b/src/ssh_zfs_client.py
@@ -1,0 +1,493 @@
+"""
+SSH-backed ZFS manager client.
+
+This client mirrors the subset of ZfsManagerClient used by the Web UI, but
+executes zfs/zpool/lsblk commands over SSH instead of talking to a ZfDash agent.
+It is read-only by default; a small allowlist of low-risk actions can be enabled
+per connection by Control Center configuration.
+"""
+
+import json
+import shlex
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import constants
+import utils
+from models import Pool, Dataset, Snapshot, ZfsObject
+from parsers.zpool import ZPoolParser
+from zfs_manager import ZfsCommandError, ZfsClientCommunicationError, build_zfs_hierarchy
+
+try:
+    import paramiko
+    PARAMIKO_AVAILABLE = True
+except ImportError:
+    paramiko = None
+    PARAMIKO_AVAILABLE = False
+
+
+SSH_ACTION_ALLOWLIST = {
+    "scrub_pool",
+    "clear_pool_errors",
+    "mount_dataset",
+    "unmount_dataset",
+}
+
+
+class SshZfsManagerClient:
+    """ZFS manager client that runs commands on a remote host via SSH."""
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        port: int = 22,
+        username: str = "root",
+        password: Optional[str] = None,
+        auth_method: str = "key",
+        key_path: Optional[str] = None,
+        allow_actions: bool = False,
+        connect_timeout: float = 15.0,
+        command_timeout: float = constants.CLIENT_ACTION_TIMEOUT,
+        reconnect_ttl: float = 30.0,
+    ):
+        if not PARAMIKO_AVAILABLE:
+            raise ZfsClientCommunicationError("paramiko is required for SSH remote monitoring")
+
+        self.host = host
+        self.port = int(port or 22)
+        self.username = username or "root"
+        self.password = password or None
+        self.auth_method = auth_method or "key"
+        self.key_path = key_path or None
+        self.allow_actions = bool(allow_actions)
+        self.connect_timeout = connect_timeout
+        self.command_timeout = command_timeout
+        self.reconnect_ttl = reconnect_ttl
+        self._client: Optional[paramiko.SSHClient] = None
+        self._last_health_check = 0.0
+        self._last_error: Optional[str] = None
+
+        self._connect()
+
+    def _connect(self) -> None:
+        self.close()
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        kwargs = {
+            "hostname": self.host,
+            "port": self.port,
+            "username": self.username,
+            "timeout": self.connect_timeout,
+            "banner_timeout": self.connect_timeout,
+            "auth_timeout": self.connect_timeout,
+        }
+        if self.auth_method == "password":
+            if not self.password:
+                raise ZfsClientCommunicationError("SSH password is required for password authentication")
+            kwargs["password"] = self.password
+            kwargs["look_for_keys"] = False
+            kwargs["allow_agent"] = False
+        else:
+            kwargs["key_filename"] = self.key_path if self.key_path else None
+            kwargs["look_for_keys"] = True
+            kwargs["allow_agent"] = True
+            if self.password:
+                kwargs["passphrase"] = self.password
+
+        try:
+            client.connect(**kwargs)
+            self._client = client
+            self._last_error = None
+            self._last_health_check = time.time()
+        except Exception as e:
+            self._last_error = str(e)
+            try:
+                client.close()
+            except Exception:
+                pass
+            raise ZfsClientCommunicationError(f"SSH connection failed: {e}") from e
+
+    def close(self) -> None:
+        if self._client:
+            try:
+                self._client.close()
+            except Exception:
+                pass
+        self._client = None
+
+    def _ensure_connected(self) -> None:
+        if not self._client or not self.is_connection_healthy():
+            self._connect()
+
+    def _run_remote(self, argv: List[str], timeout: Optional[float] = None) -> Tuple[int, str, str]:
+        self._ensure_connected()
+        command = shlex.join([str(part) for part in argv])
+        try:
+            stdin, stdout, stderr = self._client.exec_command(
+                command,
+                timeout=timeout or self.command_timeout,
+            )
+            rc = stdout.channel.recv_exit_status()
+            out = stdout.read().decode("utf-8", errors="replace")
+            err = stderr.read().decode("utf-8", errors="replace")
+            self._last_error = None
+            return rc, out, err
+        except Exception as e:
+            self._last_error = str(e)
+            self.close()
+            raise ZfsClientCommunicationError(f"SSH command failed: {e}") from e
+
+    def _run_shell(self, command: str, timeout: Optional[float] = None) -> Tuple[int, str, str]:
+        self._ensure_connected()
+        try:
+            stdin, stdout, stderr = self._client.exec_command(
+                command,
+                timeout=timeout or self.command_timeout,
+            )
+            rc = stdout.channel.recv_exit_status()
+            out = stdout.read().decode("utf-8", errors="replace")
+            err = stderr.read().decode("utf-8", errors="replace")
+            self._last_error = None
+            return rc, out, err
+        except Exception as e:
+            self._last_error = str(e)
+            self.close()
+            raise ZfsClientCommunicationError(f"SSH command failed: {e}") from e
+
+    def _raise_if_failed(self, rc: int, stderr: str, command: List[str], message: str) -> None:
+        if rc != 0:
+            raise ZfsCommandError(message, f"{shlex.join(command)}\n{stderr.strip()}")
+
+    def _send_request(self, command: str, *args, timeout: float = constants.CLIENT_ACTION_TIMEOUT, **kwargs) -> Dict[str, Any]:
+        handlers = {
+            "list_pools": self._cmd_list_pools,
+            "list_all_datasets_snapshots": self._cmd_list_all_datasets_snapshots,
+            "get_pool_status": self._cmd_get_pool_status,
+            "get_pool_status_structure": self._cmd_get_pool_status_structure,
+            "get_pool_list_verbose": self._cmd_get_pool_list_verbose,
+            "get_pool_iostat_verbose": self._cmd_get_pool_iostat_verbose,
+            "get_all_properties_with_sources": self._cmd_get_all_properties_with_sources,
+            "list_importable_pools": self._cmd_list_importable_pools,
+            "list_block_devices": self._cmd_list_block_devices,
+        }
+
+        if command in SSH_ACTION_ALLOWLIST:
+            if not self.allow_actions:
+                raise ZfsCommandError("SSH remote is read-only. Enable SSH actions for this connection to run this command.")
+            return {"status": "success", "data": self._cmd_allowed_action(command, *args, **kwargs)}
+
+        if command not in handlers:
+            raise ZfsCommandError(f"SSH remote is read-only or does not support command '{command}'")
+
+        return {"status": "success", "data": handlers[command](*args, **kwargs)}
+
+    def _cmd_list_pools(self) -> List[Dict[str, Any]]:
+        cmd = ["zpool", "list", "-H", "-o", ",".join(constants.ZPOOL_PROPS)]
+        rc, out, err = self._run_remote(cmd)
+        self._raise_if_failed(rc, err, cmd, "Failed to list pools.")
+        pools = []
+        for line in out.strip().splitlines():
+            if not line:
+                continue
+            values = line.strip().split("\t")
+            if len(values) == len(constants.ZPOOL_PROPS):
+                pools.append(dict(zip(constants.ZPOOL_PROPS, values)))
+        return pools
+
+    def _cmd_list_all_datasets_snapshots(self) -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        ds_cmd = ["zfs", "list", "-H", "-r", "-o", ",".join(constants.ZFS_DATASET_PROPS), "-t", "filesystem,volume"]
+        rc, out, err = self._run_remote(ds_cmd)
+        self._raise_if_failed(rc, err, ds_cmd, "Failed to list datasets/volumes.")
+        for line in out.strip().splitlines():
+            values = line.strip().split("\t")
+            if len(values) == len(constants.ZFS_DATASET_PROPS):
+                items.append(dict(zip(constants.ZFS_DATASET_PROPS, values)))
+
+        snap_cmd = ["zfs", "list", "-H", "-r", "-o", ",".join(constants.ZFS_SNAPSHOT_PROPS), "-t", "snapshot"]
+        rc, out, err = self._run_remote(snap_cmd)
+        if rc == 0:
+            for line in out.strip().splitlines():
+                values = line.strip().split("\t")
+                if len(values) == len(constants.ZFS_SNAPSHOT_PROPS):
+                    props = dict(zip(constants.ZFS_SNAPSHOT_PROPS, values))
+                    props["type"] = "snapshot"
+                    items.append(props)
+        elif "does not exist" not in err.lower() and "no datasets available" not in err.lower():
+            raise ZfsCommandError("Failed to list snapshots.", err)
+        return items
+
+    def _cmd_get_pool_status(self, pool_name: str) -> str:
+        cmd = ["zpool", "status", "-v", "-P", pool_name]
+        rc, out, err = self._run_remote(cmd)
+        self._raise_if_failed(rc, err, cmd, f"Failed to get status for pool '{pool_name}'.")
+        return out.strip()
+
+    def _cmd_get_pool_status_structure(self, pool_name: Optional[str] = None) -> Dict[str, Any]:
+        cmd = ZPoolParser.get_status_command(pool_name)
+        rc, out, err = self._run_remote(cmd)
+        self._raise_if_failed(rc, err, cmd, "Failed to get pool status structure.")
+        return ZPoolParser.parse_status(out, pool_name)
+
+    def _cmd_get_pool_list_verbose(self, pool_name: str) -> str:
+        cmd = ["zpool", "list", "-v", pool_name]
+        rc, out, err = self._run_remote(cmd)
+        self._raise_if_failed(rc, err, cmd, f"Failed to get verbose list for pool '{pool_name}'.")
+        return out.strip()
+
+    def _cmd_get_pool_iostat_verbose(self, pool_name: str) -> str:
+        cmd = ["zpool", "iostat", "-v", pool_name]
+        rc, out, err = self._run_remote(cmd)
+        self._raise_if_failed(rc, err, cmd, f"Failed to get iostat for pool '{pool_name}'.")
+        return out.strip()
+
+    def _cmd_get_all_properties_with_sources(self, obj_name: str) -> Dict[str, Dict[str, str]]:
+        properties: Dict[str, Dict[str, str]] = {}
+        if "/" not in obj_name:
+            pool_cmd = ["zpool", "get", "-H", "-p", "-o", "name,property,value,source", "all", obj_name]
+            rc, out, err = self._run_remote(pool_cmd)
+            self._raise_if_failed(rc, err, pool_cmd, f"Failed to get pool properties for '{obj_name}'.")
+            self._parse_properties(out, properties)
+
+        zfs_cmd = ["zfs", "get", "-H", "-p", "-o", "name,property,value,source", "all", obj_name]
+        rc, out, err = self._run_remote(zfs_cmd)
+        self._raise_if_failed(rc, err, zfs_cmd, f"Failed to get properties for '{obj_name}'.")
+        self._parse_properties(out, properties)
+        return properties
+
+    @staticmethod
+    def _parse_properties(output: str, properties: Dict[str, Dict[str, str]]) -> None:
+        for line in output.strip().splitlines():
+            try:
+                _name, prop, value, source = line.strip().split("\t", 3)
+                properties[prop] = {"value": value, "source": source}
+            except ValueError:
+                continue
+
+    def _cmd_list_importable_pools(self, search_dirs: Optional[List[str]] = None) -> List[Dict[str, str]]:
+        cmd = ["zpool", "import"]
+        if search_dirs:
+            for path in search_dirs:
+                cmd.extend(["-d", path])
+        rc, out, err = self._run_remote(cmd)
+        if "no pools available for import" in err.lower() or not out.strip():
+            return []
+        self._raise_if_failed(rc, err, cmd, "Failed to search for importable pools.")
+        pools = []
+        current = None
+        config_lines = []
+        for line in out.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if ":" in stripped:
+                key, value = stripped.split(":", 1)
+                key, value = key.strip(), value.strip()
+                if key == "pool":
+                    if current:
+                        current["config"] = "\n".join(config_lines).strip()
+                        pools.append(current)
+                    current = {"name": value, "id": "", "state": "", "action": "", "config": ""}
+                    config_lines = []
+                elif current and key in current:
+                    current[key] = value
+                elif current and key == "config":
+                    config_lines.append(value)
+            elif current and config_lines:
+                config_lines.append(stripped)
+        if current:
+            current["config"] = "\n".join(config_lines).strip()
+            pools.append(current)
+        return pools
+
+    def _cmd_list_block_devices(self) -> Dict[str, Any]:
+        cmd = "lsblk -Jpbn -o PATH,NAME,KNAME,PKNAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,MODEL,SERIAL,ROTA,RO,RM,TRAN 2>/dev/null"
+        rc, out, err = self._run_shell(cmd, timeout=constants.CLIENT_REQUEST_TIMEOUT)
+        if rc != 0:
+            return {"error": err.strip() or "Failed to list remote block devices", "all_devices": [], "devices": [], "platform": "linux"}
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError as e:
+            return {"error": f"Failed to parse lsblk JSON: {e}", "all_devices": [], "devices": [], "platform": "linux"}
+
+        all_devices = []
+
+        def flatten(items):
+            for item in items or []:
+                path = item.get("path") or item.get("name")
+                dev = {
+                    "name": path,
+                    "path": path,
+                    "kname": item.get("kname"),
+                    "pkname": item.get("pkname"),
+                    "type": item.get("type"),
+                    "size": utils.format_size(item.get("size")) if isinstance(item.get("size"), int) else item.get("size"),
+                    "fstype": item.get("fstype") or "",
+                    "mountpoint": item.get("mountpoint") or "",
+                    "model": item.get("model") or "",
+                    "serial": item.get("serial") or "",
+                    "rota": item.get("rota"),
+                    "ro": item.get("ro"),
+                    "rm": item.get("rm"),
+                    "tran": item.get("tran") or "",
+                    "eligible": item.get("type") == "disk" and not item.get("mountpoint") and item.get("ro") != 1,
+                }
+                all_devices.append(dev)
+                flatten(item.get("children"))
+
+        flatten(data.get("blockdevices"))
+        devices = [d for d in all_devices if d.get("eligible")]
+        return {"all_devices": all_devices, "devices": devices, "platform": "linux"}
+
+    def _cmd_allowed_action(self, command: str, *args, **kwargs):
+        if command == "scrub_pool":
+            pool_name = args[0] if args else kwargs.get("pool_name")
+            stop = kwargs.get("stop", False)
+            cmd = ["zpool", "scrub"]
+            if stop:
+                cmd.append("-s")
+            cmd.append(pool_name)
+        elif command == "clear_pool_errors":
+            pool_name = args[0] if args else kwargs.get("pool_name")
+            cmd = ["zpool", "clear", pool_name]
+        elif command == "mount_dataset":
+            dataset = args[0] if args else kwargs.get("full_dataset_name")
+            cmd = ["zfs", "mount", dataset]
+        elif command == "unmount_dataset":
+            dataset = args[0] if args else kwargs.get("full_dataset_name")
+            cmd = ["zfs", "unmount", dataset]
+        else:
+            raise ZfsCommandError(f"SSH action '{command}' is not allowed")
+
+        if any(part is None or part == "" for part in cmd):
+            raise ZfsCommandError(f"Missing required argument for SSH action '{command}'")
+        rc, out, err = self._run_remote(cmd)
+        self._raise_if_failed(rc, err, cmd, f"Failed to execute SSH action '{command}'.")
+        return out.strip()
+
+    def get_all_zfs_data(self) -> List[Pool]:
+        try:
+            pools_raw_data = self._send_request("list_pools")["data"]
+            items_raw_data = self._send_request("list_all_datasets_snapshots")["data"]
+        except Exception as e:
+            raise ZfsCommandError(f"Failed initial data fetch: {e}") from e
+
+        pool_statuses = {}
+        pool_vdev_trees = {}
+        for pool_props in pools_raw_data:
+            pool_name = pool_props.get("name")
+            if not pool_name:
+                continue
+            try:
+                pool_statuses[pool_name] = self._send_request("get_pool_status", pool_name)["data"]
+            except Exception as e:
+                pool_statuses[pool_name] = f"Error fetching status: {e}"
+            try:
+                structure = self._send_request("get_pool_status_structure", pool_name)["data"]
+                pool_vdev_trees[pool_name] = structure.get("pools", {}).get(pool_name, {}).get("vdev_tree", {})
+            except Exception:
+                pool_vdev_trees[pool_name] = {}
+
+        flat_list: List[ZfsObject] = []
+        for props in pools_raw_data:
+            pool_name = props.get("name", "?")
+            flat_list.append(Pool(
+                name=pool_name,
+                health=props.get("health", "?"),
+                size=utils.parse_size(props.get("size")),
+                alloc=utils.parse_size(props.get("alloc")),
+                free=utils.parse_size(props.get("free")),
+                frag=props.get("frag", "-"),
+                cap=props.get("cap", "-"),
+                dedup=props.get("dedup", "?"),
+                guid=props.get("guid", ""),
+                properties=props,
+                status_details=pool_statuses.get(pool_name, "Status unavailable"),
+                vdev_tree=pool_vdev_trees.get(pool_name, {}),
+            ))
+
+        for props in items_raw_data:
+            item_type = props.get("type")
+            name = props.get("name", "?")
+            if not name or name == "?":
+                continue
+            if item_type == "snapshot":
+                ds_name, s_name = (name.rsplit("@", 1) + [""])[:2] if "@" in name else ("", "")
+                if not ds_name:
+                    continue
+                p_name = ds_name.split("/")[0] if "/" in ds_name else ds_name
+                snap = Snapshot(
+                    name=s_name,
+                    pool_name=p_name,
+                    dataset_name=ds_name,
+                    used=utils.parse_size(props.get("used")),
+                    referenced=utils.parse_size(props.get("referenced")),
+                    creation_time=props.get("creation", "-"),
+                    properties=props,
+                )
+                snap.obj_type = "snapshot"
+                snap.properties["full_snapshot_name"] = name
+                flat_list.append(snap)
+            elif item_type in ["filesystem", "volume"]:
+                p_name = name.split("/")[0] if "/" in name else name
+                encryption_prop = props.get("encryption", "off")
+                flat_list.append(Dataset(
+                    name=name,
+                    pool_name=p_name,
+                    used=utils.parse_size(props.get("used")),
+                    available=utils.parse_size(props.get("available")),
+                    referenced=utils.parse_size(props.get("referenced")),
+                    mountpoint=props.get("mountpoint", "-"),
+                    obj_type="volume" if item_type == "volume" else "dataset",
+                    properties=props,
+                    is_encrypted=encryption_prop not in ("off", "-", None),
+                    is_mounted=(props.get("mounted", "no") == "yes"),
+                ))
+
+        return build_zfs_hierarchy(flat_list)
+
+    def get_all_properties_with_sources(self, obj_name: str) -> Tuple[bool, Dict[str, Dict[str, str]], str]:
+        try:
+            return True, self._send_request("get_all_properties_with_sources", obj_name)["data"], ""
+        except Exception as e:
+            return False, {}, str(e)
+
+    def execute_generic_action(self, command: str, success_msg: str, *args, **kwargs) -> Tuple[bool, str]:
+        response = self._send_request(command, *args, **kwargs)
+        data = response.get("data")
+        return True, f"{success_msg}{f': {data}' if data else ''}"
+
+    def list_importable_pools(self, search_dirs: Optional[List[str]] = None) -> Tuple[bool, str, List[Dict[str, str]]]:
+        try:
+            return True, "", self._send_request("list_importable_pools", search_dirs=search_dirs)["data"]
+        except Exception as e:
+            return False, str(e), []
+
+    def list_block_devices(self) -> Dict[str, Any]:
+        try:
+            return self._send_request("list_block_devices", timeout=constants.CLIENT_REQUEST_TIMEOUT)["data"]
+        except Exception as e:
+            return {"error": str(e), "all_devices": [], "devices": [], "platform": "linux"}
+
+    def is_connection_healthy(self) -> bool:
+        if not self._client:
+            return False
+        transport = self._client.get_transport()
+        if not transport or not transport.is_active():
+            return False
+        now = time.time()
+        if now - self._last_health_check < self.reconnect_ttl:
+            return True
+        try:
+            stdin, stdout, stderr = self._client.exec_command("true", timeout=5.0)
+            rc = stdout.channel.recv_exit_status()
+            self._last_health_check = now
+            return rc == 0
+        except Exception as e:
+            self._last_error = str(e)
+            return False
+
+    def get_connection_error(self) -> Optional[str]:
+        return self._last_error

--- a/src/static/js/modules/api.js
+++ b/src/static/js/modules/api.js
@@ -56,6 +56,7 @@ export async function apiCall(endpoint, method = 'GET', body = null) {
                     errorData.error = jsonErrorData.error || errorData.error;
                     errorData.details = jsonErrorData.details || errorData.details;
                     errorData.status = jsonErrorData.status || 'error';
+                    errorData.remote_died = Boolean(jsonErrorData.remote_died);
                 } catch (parseError) {
                     console.error(`API call to ${endpoint} failed with status ${statusCode}, but couldn't parse JSON error response:`, parseError);
                     errorData.details = "Failed to parse error response from server.";
@@ -92,7 +93,9 @@ export async function apiCall(endpoint, method = 'GET', body = null) {
     } catch (error) {
         if (error.message !== "UnauthorizedRedirect") {
             console.error(`API call to ${endpoint} failed:`, error);
-            if (error.data) {
+            if (error.data?.remote_died) {
+                window.dispatchEvent(new CustomEvent('zfdash:remote-died', { detail: error.data }));
+            } else if (error.data) {
                 showErrorAlert(`API Error: ${endpoint}`, `${error.message}\n\nDetails: ${error.details || 'None'}`);
             }
         }

--- a/src/static/js/modules/app.js
+++ b/src/static/js/modules/app.js
@@ -107,20 +107,7 @@ async function doHealthCheck() {
 
         // Check for remote agent death
         if (data.remote_died) {
-            daemonDisconnected = true;
-            stopHealthCheck();
-            showDaemonDisconnectedOverlay(
-                data.message || 'Remote agent connection lost.',
-                handleReconnect,
-                {
-                    title: 'Remote Agent Disconnected',
-                    showDaemonHelp: false,
-                    showSwitchAgentButton: true,
-                    reconnectButtonText: 'Connect Local'  // Clarify what Reconnect does
-                }
-            );
-            // Don't auto-reconnect for remote - let user decide
-            updateConnectionIndicator();  // Update navbar to show Local
+            handleRemoteDied(data.message || 'Remote agent connection lost.');
             return false;
         }
 
@@ -169,6 +156,28 @@ function stopHealthCheck() {
         healthCheckInterval = null;
     }
     healthCheckActive = false;
+}
+
+function handleRemoteDied(message = 'Remote agent connection lost.') {
+    if (daemonDisconnected) return;
+
+    daemonDisconnected = true;
+    stopHealthCheck();
+    hideModal();
+    showDaemonDisconnectedOverlay(
+        message,
+        null,
+        {
+            title: 'Remote Agent Disconnected',
+            showDaemonHelp: false,
+            showSwitchAgentButton: false,
+            reconnectButtonText: 'Open Control Center',
+            reconnectButtonIcon: 'bi-hdd-network-fill',
+            reconnectButtonHref: '/control-center',
+            helpText: 'Open Control Center, connect the SSH host again, then switch to it.'
+        }
+    );
+    updateConnectionIndicator();
 }
 
 /**
@@ -526,6 +535,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // CRITICAL: This enables fetchAndRenderData() to be called after successful authentication
     // Without this, the app will authenticate but never load data!
     setAuthCallbacks(fetchAndRenderData, clearSelection);
+
+    window.addEventListener('zfdash:remote-died', (event) => {
+        handleRemoteDied(event.detail?.details || event.detail?.error || 'Remote agent connection lost.');
+    });
 
     // STEP 6: Set up event listeners for UI interactions
     // --- Authentication Related Listeners ---

--- a/src/static/js/modules/control-center-api.js
+++ b/src/static/js/modules/control-center-api.js
@@ -21,11 +21,11 @@ export async function listAgents() {
  * @param {boolean} useTls - Whether to use TLS (default: true)
  * @returns {Promise<Object>} Response with success status
  */
-export async function addAgent(alias, host, port, useTls = true) {
+export async function addAgent(alias, host, port, useTls = true, options = {}) {
     const response = await fetch('/api/cc/add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ alias, host, port, use_tls: useTls })
+        body: JSON.stringify({ alias, host, port, use_tls: useTls, ...options })
     });
     return await response.json();
 }
@@ -50,7 +50,7 @@ export async function removeAgent(alias) {
  * @param {string} password - Admin password
  * @returns {Promise<Object>} Response with success status
  */
-export async function connectAgent(alias, password) {
+export async function connectAgent(alias, password = '') {
     const response = await fetch('/api/cc/connect', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -134,7 +134,7 @@ export async function discoverAgents(timeout = 3) {
  * @param {boolean} useTls - New TLS setting
  * @returns {Promise<Object>} Response with success status
  */
-export async function updateAgent(oldAlias, newAlias, host, port, useTls) {
+export async function updateAgent(oldAlias, newAlias, host, port, useTls, options = {}) {
     const response = await fetch('/api/cc/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -143,7 +143,8 @@ export async function updateAgent(oldAlias, newAlias, host, port, useTls) {
             alias: newAlias,
             host,
             port,
-            use_tls: useTls
+            use_tls: useTls,
+            ...options
         })
     });
     return await response.json();

--- a/src/static/js/modules/control-center.js
+++ b/src/static/js/modules/control-center.js
@@ -43,6 +43,7 @@ async function init() {
 
     // Set up event listeners
     setupEventListeners();
+    handleConnectionTypeChange();
 
     // Set up vault status card
     setupVaultStatus();
@@ -63,6 +64,10 @@ function setupEventListeners() {
     if (addForm) {
         addForm.addEventListener('submit', handleAddAgent);
     }
+    document.getElementById('connection-type')?.addEventListener('change', handleConnectionTypeChange);
+    document.getElementById('edit-type')?.addEventListener('change', handleEditTypeChange);
+    document.getElementById('ssh-auth-method')?.addEventListener('change', handleSshAuthMethodChange);
+    document.getElementById('edit-auth-method')?.addEventListener('change', handleEditAuthMethodChange);
 
     // Password form
     const passwordForm = document.getElementById('password-form');
@@ -124,16 +129,72 @@ function setupEventListeners() {
     }
 }
 
+function handleConnectionTypeChange() {
+    const type = document.getElementById('connection-type')?.value || 'agent';
+    const isSsh = type === 'ssh';
+    document.querySelectorAll('.ssh-field').forEach(el => {
+        el.style.display = isSsh ? '' : 'none';
+    });
+    const tlsGroup = document.getElementById('agent-tls-group');
+    if (tlsGroup) tlsGroup.style.display = isSsh ? 'none' : '';
+    const portField = document.getElementById('agent-port');
+    if (portField) portField.value = isSsh ? '22' : '5555';
+    const discoverBtn = document.getElementById('discover-btn');
+    if (discoverBtn) discoverBtn.style.display = isSsh ? 'none' : '';
+    handleSshAuthMethodChange();
+}
+
+function handleEditTypeChange() {
+    const type = document.getElementById('edit-type')?.value || 'agent';
+    const isSsh = type === 'ssh';
+    document.querySelectorAll('.edit-ssh-field').forEach(el => {
+        el.style.display = isSsh ? '' : 'none';
+    });
+    const tlsField = document.getElementById('edit-use-tls');
+    const tlsWrapper = tlsField?.closest('.form-check');
+    if (tlsWrapper) tlsWrapper.style.display = isSsh ? 'none' : '';
+    const portField = document.getElementById('edit-port');
+    if (portField) {
+        const currentPort = parseInt(portField.value);
+        if (isSsh && (!currentPort || currentPort === 5555)) portField.value = '22';
+        if (!isSsh && (!currentPort || currentPort === 22)) portField.value = '5555';
+    }
+    handleEditAuthMethodChange();
+}
+
+function handleSshAuthMethodChange() {
+    const isSsh = (document.getElementById('connection-type')?.value || 'agent') === 'ssh';
+    const authMethod = document.getElementById('ssh-auth-method')?.value || 'password';
+    const keyPathField = document.getElementById('ssh-key-path');
+    const keyPathWrapper = keyPathField?.closest('.ssh-field');
+    if (keyPathWrapper) keyPathWrapper.style.display = isSsh && authMethod === 'key' ? '' : 'none';
+    if (keyPathField && authMethod !== 'key') keyPathField.value = '';
+}
+
+function handleEditAuthMethodChange() {
+    const isSsh = (document.getElementById('edit-type')?.value || 'agent') === 'ssh';
+    const authMethod = document.getElementById('edit-auth-method')?.value || 'password';
+    const keyPathField = document.getElementById('edit-ssh-key-path');
+    const keyPathWrapper = keyPathField?.closest('.edit-ssh-field');
+    if (keyPathWrapper) keyPathWrapper.style.display = isSsh && authMethod === 'key' ? '' : 'none';
+    if (keyPathField && authMethod !== 'key') keyPathField.value = '';
+}
+
 /**
  * Handle add agent form submission
  */
 async function handleAddAgent(e) {
     e.preventDefault();
 
+    const type = document.getElementById('connection-type')?.value || 'agent';
     const alias = document.getElementById('agent-alias').value.trim();
     const host = document.getElementById('agent-host').value.trim();
     const port = parseInt(document.getElementById('agent-port').value);
     const useTls = document.getElementById('agent-use-tls').checked;
+    const sshUser = document.getElementById('ssh-user')?.value.trim() || 'root';
+    const authMethod = document.getElementById('ssh-auth-method')?.value || 'password';
+    const sshKeyPath = authMethod === 'key' ? (document.getElementById('ssh-key-path')?.value.trim() || '') : '';
+    const allowSshActions = document.getElementById('ssh-allow-actions')?.checked || false;
 
     if (!alias || !host || !port) {
         showError('All fields are required');
@@ -141,13 +202,21 @@ async function handleAddAgent(e) {
     }
 
     try {
-        const result = await api.addAgent(alias, host, port, useTls);
+        const result = await api.addAgent(alias, host, port, useTls, {
+            type,
+            ssh_user: sshUser,
+            auth_method: authMethod,
+            ssh_key_path: sshKeyPath,
+            allow_ssh_actions: allowSshActions
+        });
 
         if (result.success) {
-            showSuccess(`Agent '${alias}' added successfully`);
+            showSuccess(`${type === 'ssh' ? 'SSH host' : 'Agent'} '${alias}' added successfully`);
             e.target.reset();
             // Re-check the TLS checkbox after form reset (it defaults to checked)
             document.getElementById('agent-use-tls').checked = true;
+            document.getElementById('connection-type').value = 'agent';
+            handleConnectionTypeChange();
             await refreshAgentsList();
         } else {
             showError(result.error || 'Failed to add agent');
@@ -190,10 +259,21 @@ async function handleRemoveAgent(alias) {
  */
 async function handleConnectAgent(alias) {
     pendingConnectAlias = alias;
+    const agent = agents.find(a => a.alias === alias);
+    const isSsh = agent?.type === 'ssh';
+    const isKeyAuth = isSsh && agent?.auth_method === 'key';
     const nameEl = document.getElementById('password-agent-name');
     if (nameEl) {
         nameEl.textContent = alias;
     }
+    const intro = document.getElementById('password-modal-intro');
+    if (intro) {
+        intro.innerHTML = isKeyAuth
+            ? `Connect to SSH host <strong>${escapeHtml(alias)}</strong>. Enter a key passphrase only if needed:`
+            : `Enter the ${isSsh ? 'SSH' : 'admin'} password for <strong>${escapeHtml(alias)}</strong>:`;
+    }
+    const label = document.getElementById('agent-password-label');
+    if (label) label.textContent = isKeyAuth ? 'Key passphrase (optional)' : 'Password';
 
     // Clear password field, error, and status
     const passwordField = document.getElementById('agent-password');
@@ -204,10 +284,11 @@ async function handleConnectAgent(alias) {
     if (passwordField) {
         passwordField.value = '';
         passwordField.dataset.fromVault = 'false';
+        passwordField.required = !isKeyAuth;
     }
     if (savedIndicator) savedIndicator.style.display = 'none';
     if (saveCheckbox) saveCheckbox.checked = false;
-    if (saveGroup) saveGroup.style.display = 'block';
+    if (saveGroup) saveGroup.style.display = isKeyAuth ? 'none' : 'block';
 
     const errorDiv = document.getElementById('password-error');
     if (errorDiv) {
@@ -222,7 +303,7 @@ async function handleConnectAgent(alias) {
     resetSubmitButton();
 
     // Check vault for saved password
-    const savedPassword = await vault.getPassword(alias);
+    const savedPassword = isKeyAuth ? null : await vault.getPassword(alias);
     if (savedPassword && passwordField) {
         passwordField.value = savedPassword;
         passwordField.dataset.fromVault = 'true';
@@ -250,8 +331,10 @@ async function handlePasswordSubmit() {
     const password = document.getElementById('agent-password').value;
     const errorDiv = document.getElementById('password-error');
     const statusDiv = document.getElementById('password-status');
+    const agent = agents.find(a => a.alias === pendingConnectAlias);
+    const passwordRequired = !agent || agent.type !== 'ssh' || agent.auth_method === 'password';
 
-    if (!password) {
+    if (passwordRequired && !password) {
         errorDiv.textContent = 'Password is required';
         errorDiv.style.display = 'block';
         return;
@@ -273,7 +356,7 @@ async function handlePasswordSubmit() {
         if (result.success) {
             // Save password to vault if checkbox checked
             const saveCheckbox = document.getElementById('save-password-checkbox');
-            if (saveCheckbox?.checked && pendingConnectAlias) {
+            if (saveCheckbox?.checked && pendingConnectAlias && password) {
                 await vault.savePassword(pendingConnectAlias, password);
             }
 
@@ -539,13 +622,18 @@ function renderAgentsList() {
  * Create agent card HTML
  */
 function createAgentCard(agent) {
+    const isSsh = agent.type === 'ssh';
     const statusBadge = agent.connected
         ? '<span class="badge bg-success status-badge">Connected</span>'
         : '<span class="badge bg-secondary status-badge">Disconnected</span>';
 
     // TLS preference/status badges
     let tlsBadge = '';
-    if (agent.connected) {
+    if (isSsh) {
+        tlsBadge = agent.allow_ssh_actions
+            ? '<span class="badge bg-warning status-badge ms-1" title="Limited SSH actions enabled">SSH Actions</span>'
+            : '<span class="badge bg-info status-badge ms-1" title="SSH read-only monitoring">SSH Read-only</span>';
+    } else if (agent.connected) {
         // Show actual connection TLS status
         tlsBadge = agent.tls_active
             ? '<span class="badge bg-info status-badge ms-1" title="Connection is encrypted">🔒 TLS</span>'
@@ -590,9 +678,10 @@ function createAgentCard(agent) {
                 <div class="row align-items-center">
                     <div class="col-md-4">
                         <h5 class="mb-1">
-                            <i class="bi bi-hdd-network me-2"></i>${escapeHtml(agent.alias)}
+                            <i class="bi ${isSsh ? 'bi-terminal' : 'bi-hdd-network'} me-2"></i>${escapeHtml(agent.alias)}
                         </h5>
-                        <small class="text-muted">${escapeHtml(agent.host)}:${agent.port}</small>
+                        <small class="text-muted">${isSsh ? `${escapeHtml(agent.ssh_user || 'root')}@` : ''}${escapeHtml(agent.host)}:${agent.port}</small>
+                        <span class="badge bg-light text-dark border ms-1">${isSsh ? 'SSH' : 'Agent'}</span>
                         <br>
                         <small class="text-muted">Last connected: ${lastConnected}</small>
                     </div>
@@ -658,9 +747,14 @@ function handleEditAgent(alias) {
     const hostField = document.getElementById('edit-host');
     const portField = document.getElementById('edit-port');
     const tlsField = document.getElementById('edit-use-tls');
+    const typeField = document.getElementById('edit-type');
+    const sshUserField = document.getElementById('edit-ssh-user');
+    const authMethodField = document.getElementById('edit-auth-method');
+    const keyPathField = document.getElementById('edit-ssh-key-path');
+    const allowActionsField = document.getElementById('edit-allow-ssh-actions');
 
     // Check if modal elements exist (might be cached page without new modal)
-    if (!oldAliasField || !aliasField || !hostField || !portField || !tlsField) {
+    if (!oldAliasField || !aliasField || !hostField || !portField || !tlsField || !typeField || !sshUserField || !authMethodField || !keyPathField || !allowActionsField) {
         showError('Edit modal not found. Please refresh the page (Ctrl+Shift+R).');
         return;
     }
@@ -671,6 +765,12 @@ function handleEditAgent(alias) {
     hostField.value = agent.host;
     portField.value = agent.port;
     tlsField.checked = agent.use_tls;
+    typeField.value = agent.type || 'agent';
+    sshUserField.value = agent.ssh_user || 'root';
+    authMethodField.value = agent.auth_method || 'password';
+    keyPathField.value = agent.ssh_key_path || '';
+    allowActionsField.checked = !!agent.allow_ssh_actions;
+    handleEditTypeChange();
 
     // Clear any previous error
     const errorDiv = document.getElementById('edit-error');
@@ -691,6 +791,11 @@ async function handleSaveEdit() {
     const host = document.getElementById('edit-host').value.trim();
     const port = parseInt(document.getElementById('edit-port').value);
     const useTls = document.getElementById('edit-use-tls').checked;
+    const type = document.getElementById('edit-type').value;
+    const sshUser = document.getElementById('edit-ssh-user').value.trim() || 'root';
+    const authMethod = document.getElementById('edit-auth-method').value;
+    const sshKeyPath = authMethod === 'key' ? document.getElementById('edit-ssh-key-path').value.trim() : '';
+    const allowSshActions = document.getElementById('edit-allow-ssh-actions').checked;
     const errorDiv = document.getElementById('edit-error');
     const saveBtn = document.getElementById('edit-save-btn');
 
@@ -707,7 +812,13 @@ async function handleSaveEdit() {
     }
 
     try {
-        const result = await api.updateAgent(oldAlias, newAlias, host, port, useTls);
+        const result = await api.updateAgent(oldAlias, newAlias, host, port, useTls, {
+            type,
+            ssh_user: sshUser,
+            auth_method: authMethod,
+            ssh_key_path: sshKeyPath,
+            allow_ssh_actions: allowSshActions
+        });
 
         if (result.success) {
             if (editAgentModal) editAgentModal.hide();
@@ -743,7 +854,8 @@ function updateModeIndicator() {
         if (localCard) localCard.classList.add('active');
         if (switchLocalBtn) switchLocalBtn.disabled = true;
     } else {
-        if (modeText) modeText.textContent = `Remote Agent: ${activeAlias}`;
+        const active = agents.find(a => a.alias === activeAlias);
+        if (modeText) modeText.textContent = `${active?.type === 'ssh' ? 'Remote SSH' : 'Remote Agent'}: ${activeAlias}`;
         if (localCard) localCard.classList.remove('active');
         if (switchLocalBtn) switchLocalBtn.disabled = false;
     }
@@ -1229,4 +1341,3 @@ if (document.readyState === 'loading') {
 } else {
     init();
 }
-

--- a/src/static/js/modules/ui.js
+++ b/src/static/js/modules/ui.js
@@ -577,7 +577,10 @@ export function showDaemonDisconnectedOverlay(message, onReconnect = null, optio
         title = 'Daemon Connection Lost',
         showDaemonHelp = true,
         showSwitchAgentButton = false,
-        reconnectButtonText = 'Reconnect'
+        reconnectButtonText = 'Reconnect',
+        reconnectButtonIcon = 'bi-arrow-repeat',
+        reconnectButtonHref = null,
+        helpText = null
     } = options;
 
     // Check if overlay already exists - update message if so
@@ -609,7 +612,11 @@ export function showDaemonDisconnectedOverlay(message, onReconnect = null, optio
         justify-content: center;
     `;
 
-    const helpHtml = showDaemonHelp ? `
+    const helpHtml = helpText ? `
+                <p style="color: #555; font-size: 0.95rem; margin-bottom: 1rem;">
+                    ${escapeHtmlForModal(helpText)}
+                </p>`
+        : showDaemonHelp ? `
                 <p style="color: #555; font-size: 0.95rem; margin-bottom: 1rem;">
                     Click <strong style="color: #6a64e8;">Reconnect</strong> to try again, or start the daemon:
                 </p>
@@ -648,10 +655,15 @@ export function showDaemonDisconnectedOverlay(message, onReconnect = null, optio
                 </div>
                 ${helpHtml}
                 <div class="d-flex gap-2">
-                    <button type="button" class="btn flex-fill text-white py-2" id="daemon-reconnect-btn" 
-                            style="background: #6a64e8; border-radius: 8px; font-weight: 500; font-size: 0.95rem;">
-                        <i class="bi bi-arrow-repeat me-1"></i>${reconnectButtonText}
-                    </button>
+                    ${reconnectButtonHref
+                        ? `<a href="${escapeHtmlForModal(reconnectButtonHref)}" class="btn flex-fill text-white py-2" id="daemon-reconnect-btn"
+                              style="background: #6a64e8; border-radius: 8px; font-weight: 500; font-size: 0.95rem; text-decoration: none;">
+                              <i class="bi ${reconnectButtonIcon} me-1"></i>${reconnectButtonText}
+                           </a>`
+                        : `<button type="button" class="btn flex-fill text-white py-2" id="daemon-reconnect-btn"
+                              style="background: #6a64e8; border-radius: 8px; font-weight: 500; font-size: 0.95rem;">
+                              <i class="bi ${reconnectButtonIcon} me-1"></i>${reconnectButtonText}
+                           </button>`}
                     ${switchAgentBtn}
                 </div>
             </div>
@@ -662,13 +674,13 @@ export function showDaemonDisconnectedOverlay(message, onReconnect = null, optio
 
     // Attach reconnect handler
     const reconnectBtn = document.getElementById('daemon-reconnect-btn');
-    if (reconnectBtn && onReconnect) {
+    if (reconnectBtn && onReconnect && !reconnectButtonHref) {
         reconnectBtn.addEventListener('click', async () => {
             reconnectBtn.disabled = true;
             reconnectBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Connecting...';
             await onReconnect();
             reconnectBtn.disabled = false;
-            reconnectBtn.innerHTML = `<i class="bi bi-arrow-repeat me-1"></i>${reconnectButtonText}`;
+            reconnectBtn.innerHTML = `<i class="bi ${reconnectButtonIcon} me-1"></i>${reconnectButtonText}`;
         });
     }
 }

--- a/src/templates/control_center.html
+++ b/src/templates/control_center.html
@@ -130,7 +130,7 @@
     <div class="row mb-4">
       <div class="col">
         <h2><i class="bi bi-hdd-network me-2"></i>Control Center</h2>
-        <p class="text-muted">Manage connections to remote ZFS daemons across your network.</p>
+        <p class="text-muted">Manage connections to remote ZFS hosts across your network.</p>
       </div>
     </div>
 
@@ -163,15 +163,22 @@
       </div>
     </div>
 
-    <!-- Add Agent Form -->
+    <!-- Add Remote Form -->
     <div class="row mb-4">
       <div class="col">
         <div class="card">
           <div class="card-header bg-primary text-white">
-            <h5 class="mb-0"><i class="bi bi-plus-circle me-2"></i>Add Remote Agent</h5>
+            <h5 class="mb-0"><i class="bi bi-plus-circle me-2"></i>Add Remote Host</h5>
           </div>
           <div class="card-body">
             <form id="add-agent-form" class="row g-3">
+              <div class="col-md-2">
+                <label for="connection-type" class="form-label">Type</label>
+                <select class="form-select" id="connection-type">
+                  <option value="agent" selected>ZfDash Agent</option>
+                  <option value="ssh">SSH Host</option>
+                </select>
+              </div>
               <div class="col-md-3">
                 <label for="agent-alias" class="form-label">Alias</label>
                 <input type="text" class="form-control" id="agent-alias" placeholder="my-server" required>
@@ -184,11 +191,34 @@
                 <label for="agent-port" class="form-label">Port</label>
                 <input type="number" class="form-control" id="agent-port" value="5555" required>
               </div>
-              <div class="col-md-2 d-flex align-items-end">
+              <div class="col-md-2 d-flex align-items-end" id="agent-tls-group">
                 <div class="form-check mb-2">
                   <input type="checkbox" class="form-check-input" id="agent-use-tls" checked>
                   <label class="form-check-label" for="agent-use-tls">
                     <i class="bi bi-shield-lock"></i> Use TLS
+                  </label>
+                </div>
+              </div>
+              <div class="col-md-2 ssh-field" style="display: none;">
+                <label for="ssh-user" class="form-label">SSH User</label>
+                <input type="text" class="form-control" id="ssh-user" value="root">
+              </div>
+              <div class="col-md-2 ssh-field" style="display: none;">
+                <label for="ssh-auth-method" class="form-label">SSH Auth</label>
+                <select class="form-select" id="ssh-auth-method">
+                  <option value="key">SSH Key / Agent</option>
+                  <option value="password" selected>Password</option>
+                </select>
+              </div>
+              <div class="col-md-3 ssh-field" style="display: none;">
+                <label for="ssh-key-path" class="form-label">Key Path</label>
+                <input type="text" class="form-control" id="ssh-key-path" placeholder="/root/.ssh/id_rsa">
+              </div>
+              <div class="col-md-3 ssh-field" style="display: none;">
+                <div class="form-check mt-4 pt-2">
+                  <input type="checkbox" class="form-check-input" id="ssh-allow-actions">
+                  <label class="form-check-label" for="ssh-allow-actions">
+                    Allow limited SSH actions
                   </label>
                 </div>
               </div>
@@ -264,10 +294,10 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
-          <p>Enter the admin password for <strong id="password-agent-name"></strong>:</p>
+          <p id="password-modal-intro">Enter the admin password for <strong id="password-agent-name"></strong>:</p>
           <form id="password-form">
             <div class="mb-3">
-              <label for="agent-password" class="form-label">Password</label>
+              <label for="agent-password" class="form-label" id="agent-password-label">Password</label>
               <div class="input-group">
                 <input type="password" class="form-control" id="agent-password" required autofocus>
                 <span class="input-group-text text-success" id="password-saved-indicator" style="display: none;"
@@ -285,7 +315,7 @@
           </form>
           <div id="password-status" class="alert alert-info align-items-center" style="display: none;">
             <span class="spinner-border spinner-border-sm me-2"></span>
-            Connecting to agent...
+            Connecting...
           </div>
           <div id="password-error" class="alert alert-danger" style="display: none;"></div>
         </div>
@@ -387,6 +417,37 @@
               <label class="form-check-label" for="edit-use-tls">
                 <i class="bi bi-shield-lock"></i> Use TLS
               </label>
+            </div>
+            <div class="mb-3">
+              <label for="edit-type" class="form-label">Type</label>
+              <select class="form-select" id="edit-type">
+                <option value="agent">ZfDash Agent</option>
+                <option value="ssh">SSH Host</option>
+              </select>
+            </div>
+            <div class="mb-3 edit-ssh-field" style="display: none;">
+              <label for="edit-ssh-user" class="form-label">SSH User</label>
+              <input type="text" class="form-control" id="edit-ssh-user">
+            </div>
+            <div class="mb-3 edit-ssh-field" style="display: none;">
+              <label for="edit-auth-method" class="form-label">SSH Auth</label>
+              <select class="form-select" id="edit-auth-method">
+                <option value="key">SSH Key / Agent</option>
+                <option value="password">Password</option>
+              </select>
+            </div>
+            <div class="mb-3 edit-ssh-field" style="display: none;">
+              <label for="edit-ssh-key-path" class="form-label">Key Path</label>
+              <input type="text" class="form-control" id="edit-ssh-key-path">
+            </div>
+            <div class="form-check mb-3 edit-ssh-field" style="display: none;">
+              <input type="checkbox" class="form-check-input" id="edit-allow-ssh-actions">
+              <label class="form-check-label" for="edit-allow-ssh-actions">
+                Allow limited SSH actions
+              </label>
+            </div>
+            <div class="alert alert-warning small edit-ssh-field" style="display: none;">
+              SSH hosts are read-only by default. Limited actions never include destroy, rollback, or receive.
             </div>
           </form>
           <div id="edit-error" class="alert alert-danger" style="display: none;"></div>

--- a/src/web_ui.py
+++ b/src/web_ui.py
@@ -377,6 +377,8 @@ def _get_zfs_client() -> ZfsManagerClient:
     """
     # Check if session says we should be in remote mode
     if control_center_manager and session.get('cc_mode') == 'remote':
+        control_center_manager.restore_active_from_session(session)
+
         # Validate remote connection (single source of truth)
         is_healthy, active_alias = control_center_manager.is_healthy_or_clear()
         
@@ -450,6 +452,14 @@ def _handle_zfs_call(func_name: str, *args, **kwargs):
                  data = result
             return jsonify(status="success", data=data)
 
+    except RemoteAgentDisconnectedError as e:
+        app.logger.warning(f"Remote connection lost while calling ZFS function '{func_name}': {e}")
+        return jsonify(
+            status="error",
+            error="Remote agent disconnected",
+            details="Reconnect the remote host in Control Center before loading remote ZFS data.",
+            remote_died=True
+        ), 409
     except (ZfsCommandError, ZfsClientCommunicationError, TimeoutError) as e:
         app.logger.error(f"Error calling ZFS function '{func_name}': {e}")
         app.logger.error(traceback.format_exc())

--- a/tests/test_ssh_remote_monitoring.py
+++ b/tests/test_ssh_remote_monitoring.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import pytest
+
+from control_center_manager import AgentConnection
+from ssh_zfs_client import SshZfsManagerClient
+from zfs_manager import ZfsCommandError
+
+
+def make_ssh_client(allow_actions=False):
+    client = SshZfsManagerClient.__new__(SshZfsManagerClient)
+    client.allow_actions = allow_actions
+    client.commands = []
+
+    def fake_run_remote(argv, timeout=None):
+        client.commands.append(argv)
+        return 0, "ok", ""
+
+    client._run_remote = fake_run_remote
+    return client
+
+
+def test_ssh_connection_serialization_round_trip():
+    conn = AgentConnection(
+        "pve",
+        "192.168.15.10",
+        22,
+        connection_type="ssh",
+        ssh_user="root",
+        auth_method="key",
+        ssh_key_path="/root/.ssh/id_ed25519",
+        allow_ssh_actions=True,
+    )
+
+    restored = AgentConnection.from_dict(conn.to_dict())
+
+    assert restored.connection_type == "ssh"
+    assert restored.host == "192.168.15.10"
+    assert restored.port == 22
+    assert restored.ssh_user == "root"
+    assert restored.auth_method == "key"
+    assert restored.ssh_key_path == "/root/.ssh/id_ed25519"
+    assert restored.allow_ssh_actions is True
+
+
+def test_ssh_remote_blocks_mutating_actions_by_default():
+    client = make_ssh_client(allow_actions=False)
+
+    with pytest.raises(ZfsCommandError, match="read-only"):
+        client._send_request("scrub_pool", "tank")
+
+
+def test_ssh_remote_rejects_destructive_actions_even_when_actions_enabled():
+    client = make_ssh_client(allow_actions=True)
+
+    with pytest.raises(ZfsCommandError):
+        client._send_request("destroy_pool", "tank")
+
+
+def test_ssh_remote_allows_allowlisted_actions_when_enabled():
+    client = make_ssh_client(allow_actions=True)
+
+    response = client._send_request("scrub_pool", "tank")
+
+    assert response["status"] == "success"
+    assert client.commands == [["zpool", "scrub", "tank"]]
+


### PR DESCRIPTION
# Add SSH remote monitoring support

## Summary
Adds SSH host support to Control Center as an alternative remote connection type alongside the existing ZfDash Agent mode.

SSH remotes support read-only ZFS monitoring over `zpool`/`zfs` commands by default, with a small allowlist of optional actions when explicitly enabled.

## Changes
- Add `SshZfsManagerClient` using Paramiko.
- Add SSH remote config fields: type, SSH user, auth method, key path, and allow actions.
- Support password auth and key/default SSH agent auth.
- Keep existing Agent mode unchanged.
- Block mutating SSH actions by default.
- Allow only limited SSH actions when enabled.
- Add UI controls for SSH host setup and editing.
- Improve remote disconnect handling in the Web UI.
- Add tests for config serialization, read-only blocking, allowlist behavior, and reconnect behavior.

## Testing
- `python -m compileall -q src tests`
- `python -m pytest tests/test_ssh_remote_monitoring.py -q`
- `node --check src/static/js/modules/control-center.js`
- `node --check src/static/js/modules/control-center-api.js`
- `node --check src/static/js/modules/api.js`
- `node --check src/static/js/modules/app.js`
- `node --check src/static/js/modules/ui.js`

Refs #22
